### PR TITLE
Refactor encryption key handling in utils

### DIFF
--- a/backend/generate_encryption_key.py
+++ b/backend/generate_encryption_key.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+Generate a valid Fernet encryption key for MCP_APIKEY_ENCRYPTION_KEY
+
+Usage:
+    python generate_encryption_key.py
+
+This will output a valid Fernet key that can be used as MCP_APIKEY_ENCRYPTION_KEY
+in your environment variables or docker-compose.yml
+"""
+from cryptography.fernet import Fernet
+
+if __name__ == "__main__":
+    key = Fernet.generate_key()
+    print("=" * 60)
+    print("Generated Fernet Encryption Key:")
+    print("=" * 60)
+    print(key.decode())
+    print("=" * 60)
+    print("\nAdd this to your docker-compose.yml or .env file:")
+    print(f'MCP_APIKEY_ENCRYPTION_KEY="{key.decode()}"')
+    print("\nOr set as environment variable:")
+    print(f'export MCP_APIKEY_ENCRYPTION_KEY="{key.decode()}"')
+    print("=" * 60)
+


### PR DESCRIPTION
- Updated the get_encryption_key function to improve handling of the MCP_APIKEY_ENCRYPTION_KEY environment variable, including whitespace stripping and enhanced validation for base64-encoded Fernet keys.
- Added detailed error handling and informative messages for invalid key formats during encryption.
- Ensured that the encryption key is consistently returned as bytes, accommodating both string and byte formats for Fernet compatibility.